### PR TITLE
cmd/goannotate/annotators, locate: provide finer grained control over which functions are annotated

### DIFF
--- a/cmd/goannotate/annotators/README.md
+++ b/cmd/goannotate/annotators/README.md
@@ -78,16 +78,17 @@ is true.
 ### Type AddLogCall
 ```go
 type AddLogCall struct {
-	Type                 string   `annotator:"name of annotator type."`
-	Name                 string   `annotator:"name of annotation."`
-	Packages             []string `annotator:"packages to be annotated"`
-	Interfaces           []string `annotator:"list of interfaces whose implementations are to have logging calls added to them."`
-	Functions            []string `annotator:"list of functionms that are to have function calls added to them."`
-	ContextType          string   `yaml:"contextType" annotator:"type for the context parameter and result."`
-	Import               string   `annotator:"import patrh for the logging function."`
-	Logcall              string   `annotator:"invocation for the logging function."`
-	IgnoreEmptyFunctions bool     `yaml:"ignoreEmptyFunctions" annotator:"if set empty functions are ignored."`
-	Concurrency          int      `annotator:"the number of goroutines to use, zero for a sensible default."`
+	Type                string   `annotator:"name of annotator type."`
+	Name                string   `annotator:"name of annotation."`
+	Packages            []string `annotator:"packages to be annotated"`
+	Interfaces          []string `annotator:"list of interfaces whose implementations are to have logging calls added to them."`
+	Functions           []string `annotator:"list of functionms that are to have function calls added to them."`
+	ContextType         string   `yaml:"contextType" annotator:"type for the context parameter and result."`
+	Import              string   `annotator:"import patrh for the logging function."`
+	Logcall             string   `annotator:"invocation for the logging function."`
+	AtLeastStatements   int      `yaml:"atLeastStatements" annotator:"the number of statements that must be present in a function in order for it to be annotated."`
+	NoAnnotationComment string   `yaml:"noAnnotationComment" annotator:"do not annotate functions that contain this comment"`
+	Concurrency         int      `annotator:"the number of goroutines to use, zero for a sensible default."`
 
 	// Used for templates.
 	FunctionName string `yaml:",omitempty"`
@@ -163,7 +164,7 @@ RmLogCall represents an annotor for removing logging calls.
 type Spec struct {
 	yaml.MapSlice
 	Name string // Name identifies a particular configuration of an annotator type.
-	Type string // Type identifies the annotation to be peformed.
+	Type string // Type identifies the annotation to be performed.
 }
 ```
 Spec represents the yaml configuration for an annotation. It has a common

--- a/cmd/goannotate/annotators/rmlogcall.go
+++ b/cmd/goannotate/annotators/rmlogcall.go
@@ -72,7 +72,7 @@ func (rc *RmLogCall) Do(ctx context.Context, root string, pkgs []string) error {
 		fn *types.Func,
 		decl *ast.FuncDecl,
 		implements []string) {
-		if !locateutil.HasBody(decl) {
+		if locateutil.FunctionStatements(decl) == 0 {
 			return
 		}
 		cmap := ast.NewCommentMap(pkg.Fset, file, file.Comments)

--- a/cmd/goannotate/annotators/testdata/config.yaml
+++ b/cmd/goannotate/annotators/testdata/config.yaml
@@ -8,7 +8,8 @@ annotations:
     contextType: context.Context
     import: cloudeng.io/go/cmd/goannotate/annotators/testdata/apilog 
     logcall: apilog.LogCallf
-    ignoreEmptyFunctions: true
+    atLeastStatements: 1
+    noAnnotationComment: "nologcall:"
   - type: cloudeng.io/go/cmd/goannotate/annotators.RmLogCall
     name: rmlegacy
     interfaces:

--- a/cmd/goannotate/annotators/testdata/impl/existing.go
+++ b/cmd/goannotate/annotators/testdata/impl/existing.go
@@ -20,3 +20,8 @@ func APINew(n int) error {
 
 func APIEmptyFunc(n int) {
 }
+
+func APINoLogCall(n int) error {
+	// nologcall:
+	return nil
+}

--- a/cmd/goannotate/config.yaml
+++ b/cmd/goannotate/config.yaml
@@ -6,6 +6,8 @@ annotations:
   # be compiled in to the goannotate binary priort to it being usable here.
   # The --list command will provide documentation on the current set of compiled
   # in annotators.
+    # AddLogcall annotates functions with a logging call that records
+    # entry/exit from them. The example here is appropriate for vanadium.
   - type: cloudeng.io/go/cmd/goannotate/annotators.AddLogCall
     name: vanadium-add-logcall
     # Packages specifies the packages to be annotated. It may be overriden
@@ -19,13 +21,19 @@ annotations:
     functions:
     # contextType is the context type used by this API.
     contextType: v.io/v23/context.T
-    # import is the import path for the logging call to be added.
+    # Import is the import path for the logging call to be added.
     import: v.io/x/ref/lib/apilog
     # logcall is the import path itself.
-    logcall: apilog.LogCallf2
-    # if ignoreEmptyFunctions is true empty functions (no body or a single
-    # return statement) will be ignored.
-    ignoreEmptyFunctions: true
+    logcall: apilog.LogCallf
+    # Functions must have at least this number of top-level statements to
+    # be worth annotating.
+    atLeastStatements: 1
+    # Do not annotate functions which have this text in any comments associated
+    # with or within the function.
+    noAnnotationComment: "nologcall:"
+    # RmLogCall removes annotations previously added to log entry/exit
+    # from a specified set of functions. The example here is appropriate for
+    # vanadium.
   - type: cloudeng.io/go/cmd/goannotate/annotators.RmLogCall
     name: vanadium-rm-logcall
     packages:
@@ -36,6 +44,8 @@ annotations:
     logcall: apilog.LogCallf
     comment: "gologcop: DO NOT EDIT, MUST BE FIRST STATEMENT"
     deferred: true
+    # EnsureCopyrightAndLicense ensures that the specified copyright and license
+    # is present at the top of every go file.
   - type: cloudeng.io/go/cmd/goannotate/annotators.EnsureCopyrightAndLicense
     name: personal-copyright
     copyright: "// Copyright 2020 Cosmos Nicolaou. All rights reserved."
@@ -47,6 +57,8 @@ annotations:
     license: "// Use of this source code is governed by the Apache-2.0\n
 // license that can be found in the LICENSE file."
 options:
+  # Default concurrency.
   concurrency: 0
 debug:
+  # Provide a file name here to enable cpu profiling.
   cpu_profile:

--- a/cmd/gomarkdown/main.go
+++ b/cmd/gomarkdown/main.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 
 	"cloudeng.io/cmdutil"
+	"cloudeng.io/cmdutil/flags"
 	"cloudeng.io/errors"
 	"cloudeng.io/go/locate"
 	"golang.org/x/tools/go/packages"
@@ -39,20 +40,6 @@ func init() {
 	flag.BoolVar(&overwriteFlag, "overwrite", false, "overwrite existing file.")
 }
 
-func validateFlags() {
-	switch markdownFlag {
-	case "github":
-	default:
-		cmdutil.Exit("unsupported mark down flavour: %v", markdownFlag)
-	}
-
-	switch gopkgSiteFlag {
-	case "pkg.go.dev", "godoc.org":
-	default:
-		cmdutil.Exit("unsupported go pkg site: %v", gopkgSiteFlag)
-	}
-}
-
 func main() {
 	ctx := context.Background()
 	flag.Parse()
@@ -66,7 +53,12 @@ func main() {
 		cmdutil.Exit("failed to run locator: %v", err)
 	}
 
-	validateFlags()
+	if err := flags.OneOf(markdownFlag).Validate("github"); err != nil {
+		cmdutil.Exit("%s", err)
+	}
+	if err := flags.OneOf(gopkgSiteFlag).Validate("pkg.go.dev", "godoc.org"); err != nil {
+		cmdutil.Exit("%s", err)
+	}
 
 	// Merge the package and any associated test packages into a single
 	// set of ast.Files for use with doc.NewFromFiles.

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module cloudeng.io/go
 go 1.14
 
 require (
-	cloudeng.io/cmdutil v0.0.0-20200414211116-3c1830e6b648
+	cloudeng.io/cmdutil v0.0.0-20200417221948-ba45244eb760
 	cloudeng.io/errors v0.0.5
 	cloudeng.io/path v0.0.3-0.20200414211116-3c1830e6b648
 	cloudeng.io/sync v0.0.5-0.20200414211116-3c1830e6b648

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-cloudeng.io/cmdutil v0.0.0-20200414211116-3c1830e6b648 h1:S7mtboPvntq8ACGcqWqIPMcSrs4wvqKo/WwmCp+S6o8=
-cloudeng.io/cmdutil v0.0.0-20200414211116-3c1830e6b648/go.mod h1:XoCeo/dKacPCgeKEVVQoGA3HLsSOtE/6mi9QpALF9tM=
+cloudeng.io/cmdutil v0.0.0-20200417221948-ba45244eb760 h1:oIpvoaIyboA6kN4WSBhnyvYoHOwwtY/EUP5MO1fkGOI=
+cloudeng.io/cmdutil v0.0.0-20200417221948-ba45244eb760/go.mod h1:EfjRRBdGt9BeDOM+2Yt8Eoj/nbDVGQebKbZdgxHcV6M=
 cloudeng.io/errors v0.0.2/go.mod h1:4iZnGEBj5F3SqTHZF6AHiFMgeHeJWJJkVHx/UwbDYok=
 cloudeng.io/errors v0.0.4/go.mod h1:4iZnGEBj5F3SqTHZF6AHiFMgeHeJWJJkVHx/UwbDYok=
 cloudeng.io/errors v0.0.5 h1:NmCUhMIvWQ/0Ny3cBWplA2RXPcnyNUiMovPe64LgX3A=
@@ -34,6 +34,5 @@ golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IV
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
-gopkg.in/jcmturner/gokrb5.v7 v7.5.0/go.mod h1:l8VISx+WGYp+Fp7KRbsiUuXTTOnxIc3Tuvyavf11/WM=
 gopkg.in/yaml.v2 v2.2.8 h1:obN1ZagJSUGI0Ek/LBmuj4SNLPfIny3KsKFopxRdj10=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/locate/locateutil/README.md
+++ b/locate/locateutil/README.md
@@ -31,11 +31,18 @@ FunctionCalls determines if the supplied function declaration contains a
 call 'callname' where callname is either a function name or a selector (eg.
 foo.bar). If deferred is true the function call must be defer'ed.
 
-### Func HasBody
+### Func FunctionHasComment
 ```go
-func HasBody(decl *ast.FuncDecl) bool
+func FunctionHasComment(decl *ast.FuncDecl, cmap ast.CommentMap, text string) bool
 ```
-HasBody returns true of the function has a body.
+FunctionHasComment returns true if any of the comments associated or within
+the function contain the specified text.
+
+### Func FunctionStatements
+```go
+func FunctionStatements(decl *ast.FuncDecl) int
+```
+FunctionStatements returns number of top-level statements in a function.
 
 ### Func ImportBlock
 ```go

--- a/locate/locateutil/comment_test.go
+++ b/locate/locateutil/comment_test.go
@@ -27,8 +27,8 @@ func TestComments(t *testing.T) {
 		deferred    bool
 		first, last string
 	}{
-		{false, "functions.go:12:2", "functions.go:14:19"}, // functinns.HasCall
-		{true, "functions.go:18:2", "functions.go:20:19"},  // functions.HasDefer
+		{false, "functions.go:12:2", "functions.go:16:19"}, // functinns.HasCall
+		{true, "functions.go:20:2", "functions.go:23:15"},  // functions.HasDefer
 	}
 
 	for i, fn := range fns {

--- a/locate/locateutil/function.go
+++ b/locate/locateutil/function.go
@@ -137,7 +137,7 @@ func (v *funcVisitor) Visit(node ast.Node) ast.Visitor {
 // 'callname' where callname is either a function name or a selector (eg. foo.bar).
 // If deferred is true the function call must be defer'ed.
 func FunctionCalls(decl *ast.FuncDecl, callname string, deferred bool) []ast.Node {
-	if !HasBody(decl) {
+	if len(decl.Body.List) == 0 {
 		return nil
 	}
 	v := &funcVisitor{
@@ -148,7 +148,23 @@ func FunctionCalls(decl *ast.FuncDecl, callname string, deferred bool) []ast.Nod
 	return v.nodes
 }
 
-// HasBody returns true of the function has a body.
-func HasBody(decl *ast.FuncDecl) bool {
-	return len(decl.Body.List) > 0
+// FunctionStatements returns number of top-level statements in a function.
+func FunctionStatements(decl *ast.FuncDecl) int {
+	return len(decl.Body.List)
+}
+
+// FunctionHasComment returns true if any of the comments associated or within
+// the function contain the specified text.
+func FunctionHasComment(decl *ast.FuncDecl, cmap ast.CommentMap, text string) bool {
+	if CommentGroupsContain([]*ast.CommentGroup{decl.Doc}, text) {
+		return true
+	}
+	for _, stmt := range decl.Body.List {
+		if cg := cmap[stmt]; cg != nil {
+			if CommentGroupsContain(cg, text) {
+				return true
+			}
+		}
+	}
+	return false
 }

--- a/locate/testdata/functions/functions.go
+++ b/locate/testdata/functions/functions.go
@@ -9,6 +9,8 @@ func Empty() {
 }
 
 func HasCall() {
+	// nologcall:
+
 	// Comment before.
 	ioutil.ReadFile("x") // Comment on the same line.
 	// Comment after.
@@ -18,6 +20,7 @@ func HasDefer() {
 	// Comment before.
 	defer ioutil.ReadFile("x") // Comment on the same line.
 	// Comment after.
+	// nologcall:
 }
 
 func HasOther() {


### PR DESCRIPTION
Provide finer grained control over which functions are annotated. In particular:
  - allow for a comment to disable annotation for a function.
  - allow for functions with less than a specified number of top level statements to be ignored.