### PR TITLE
cmd/gomarkdown: extend output to include type functions, vars etc

### DIFF
--- a/cmd/goannotate/annotators/README.md
+++ b/cmd/goannotate/annotators/README.md
@@ -78,6 +78,34 @@ type AddLogCall struct {
 AddLogCall represents an annotator for adding a function call that logs the
 entry and exit to every function and method that is matched by the locator.
 
+### Methods
+
+```go
+func (lc *AddLogCall) Describe() string
+```
+Describe implements annotators.Annotation.
+
+
+```go
+func (lc *AddLogCall) Do(ctx context.Context, root string, pkgs []string) error
+```
+Do implements annotators.Annotation.
+
+
+```go
+func (lc *AddLogCall) New(name string) Annotation
+```
+New implements annotators.Annotator.
+
+
+```go
+func (lc *AddLogCall) UnmarshalYAML(buf []byte) error
+```
+UnmarshalYAML implements annotators.Annotation.
+
+
+
+
 ### Type Annotation
 ```go
 type Annotation interface {
@@ -95,6 +123,16 @@ type Annotation interface {
 ```
 Annotation represents a configured instance of an Annotator.
 
+### Functions
+
+```go
+func Lookup(name string) Annotation
+```
+Lookup returns the annotation with the specified typeName, if any.
+
+
+
+
 ### Type Annotator
 ```go
 type Annotator interface {
@@ -105,6 +143,7 @@ type Annotator interface {
 }
 ```
 Annotator represents the interface that all annotators must implement.
+
 
 ### Type EnsureCopyrightAndLicense
 ```go
@@ -120,6 +159,34 @@ type EnsureCopyrightAndLicense struct {
 EnsureCopyrightAndLicense represents an annotator that can insert or replace
 copyright and license headers from go source code files.
 
+### Methods
+
+```go
+func (ec *EnsureCopyrightAndLicense) Describe() string
+```
+Describe implements annotators.Annotations.
+
+
+```go
+func (ec *EnsureCopyrightAndLicense) Do(ctx context.Context, root string, pkgs []string) error
+```
+Do implements annotators.Annotations.
+
+
+```go
+func (ec *EnsureCopyrightAndLicense) New(name string) Annotation
+```
+New implements annotators.Annotators.
+
+
+```go
+func (ec *EnsureCopyrightAndLicense) UnmarshalYAML(buf []byte) error
+```
+UnmarshalYAML implements annotators.Annotations.
+
+
+
+
 ### Type EssentialOptions
 ```go
 type EssentialOptions struct {
@@ -132,6 +199,7 @@ type EssentialOptions struct {
 EssentialOptions represents the configuration options required for all
 annotations.
 
+
 ### Type LocateOptions
 ```go
 type LocateOptions struct {
@@ -141,6 +209,7 @@ type LocateOptions struct {
 ```
 LocateOptions represents the configuration options used to locate specific
 interfaces and/or functions.
+
 
 ### Type RmLogCall
 ```go
@@ -155,6 +224,34 @@ type RmLogCall struct {
 ```
 RmLogCall represents an annotor for removing logging calls.
 
+### Methods
+
+```go
+func (rc *RmLogCall) Describe() string
+```
+Describe implements annotators.Annotation.
+
+
+```go
+func (rc *RmLogCall) Do(ctx context.Context, root string, pkgs []string) error
+```
+Do implements annotators.Annotation.
+
+
+```go
+func (rc *RmLogCall) New(name string) Annotation
+```
+New implements annotators.Annotator.
+
+
+```go
+func (rc *RmLogCall) UnmarshalYAML(buf []byte) error
+```
+UnmarshalYAML implements annotators.Annotation.
+
+
+
+
 ### Type Spec
 ```go
 type Spec struct {
@@ -167,6 +264,16 @@ Spec represents the yaml configuration for an annotation. It has a common
 field for the type and name of the annotator but all other fields are
 delegated to the Unmarshal method of the annotator specuifed by the Type
 field.
+
+### Methods
+
+```go
+func (s *Spec) UnmarshalYAML(unmarshal func(interface{}) error) error
+```
+UnmarshalYAML implements yaml.Unmarshaler.
+
+
+
 
 
 

--- a/cmd/goannotate/annotators/functions/README.md
+++ b/cmd/goannotate/annotators/functions/README.md
@@ -76,6 +76,16 @@ type CallGenerator interface {
 CallGenerator represents the ability to generate code for a function call
 using arguments taken from a function call signature.
 
+### Functions
+
+```go
+func Lookup(typeName string) CallGenerator
+```
+Lookup returns the CallGenerator, if any, with the specified type.
+
+
+
+
 ### Type EssentialOptions
 ```go
 type EssentialOptions struct {
@@ -86,6 +96,7 @@ type EssentialOptions struct {
 ```
 EssentialOptions represents the configuration options required for all
 function generators.
+
 
 ### Type LogCallWithContext
 ```go
@@ -101,6 +112,33 @@ with the following signature:
 
 See LogCallWithContextDescription for a complete description.
 
+### Methods
+
+```go
+func (lc *LogCallWithContext) Describe() string
+```
+Describe implements functions.CallGenerator.
+
+
+```go
+func (lc *LogCallWithContext) Generate(fset *token.FileSet, fn *types.Func, decl *ast.FuncDecl) (string, error)
+```
+
+
+```go
+func (lc *LogCallWithContext) Import() string
+```
+Import implements functions.CallGenerator.
+
+
+```go
+func (lc *LogCallWithContext) UnmarshalYAML(buf []byte) error
+```
+UnmarshalYAML implements functions.CallGenerator.
+
+
+
+
 ### Type SimpleLogCall
 ```go
 type SimpleLogCall struct {
@@ -111,6 +149,33 @@ type SimpleLogCall struct {
 SimpleLogCall represents a function call generator for a logging call with
 the same signature as log.Callf and fmt.Printf.
 
+### Methods
+
+```go
+func (sl *SimpleLogCall) Describe() string
+```
+Describe implements functions.CallGenerator.
+
+
+```go
+func (sl *SimpleLogCall) Generate(fset *token.FileSet, fn *types.Func, decl *ast.FuncDecl) (string, error)
+```
+
+
+```go
+func (sl *SimpleLogCall) Import() string
+```
+Import implements functions.CallGenerator.
+
+
+```go
+func (sl *SimpleLogCall) UnmarshalYAML(buf []byte) error
+```
+UnmarshalYAML implements functions.CallGenerator.
+
+
+
+
 ### Type Spec
 ```go
 type Spec struct {
@@ -119,6 +184,16 @@ type Spec struct {
 }
 ```
 Spec represents the yaml configuration for a function call generator.
+
+### Methods
+
+```go
+func (s *Spec) UnmarshalYAML(unmarshal func(interface{}) error) error
+```
+UnmarshalYAML implements yaml.Unmarshaler.
+
+
+
 
 
 

--- a/cmd/goannotate/annotators/internal/testutil/README.md
+++ b/cmd/goannotate/annotators/internal/testutil/README.md
@@ -50,5 +50,14 @@ type DiffReport struct {
 }
 ```
 
+### Functions
+
+```go
+func DiffMultipleFiles(t *testing.T, a, b []string) []DiffReport
+```
+
+
+
+
 
 

--- a/cmd/gomarkdown/main.go
+++ b/cmd/gomarkdown/main.go
@@ -91,7 +91,6 @@ func main() {
 			errs.Append(fmt.Errorf("failed to create ast.Package for %v: %v", pkg.PkgPath, err))
 			return
 		}
-
 		// Merge all of the examples into the single package level Examples
 		// since the markdown will list all of the examples in one section.
 		examples := docPkg.Examples
@@ -101,6 +100,7 @@ func main() {
 		for _, tyeg := range docPkg.Types {
 			examples = append(examples, tyeg.Examples...)
 		}
+
 		docPkg.Examples = examples
 		st := newOutputState(docPkg, pkg,
 			markdownFlavour(markdownFlag),

--- a/cmd/gomarkdown/main.go
+++ b/cmd/gomarkdown/main.go
@@ -91,6 +91,7 @@ func main() {
 			errs.Append(fmt.Errorf("failed to create ast.Package for %v: %v", pkg.PkgPath, err))
 			return
 		}
+
 		// Merge all of the examples into the single package level Examples
 		// since the markdown will list all of the examples in one section.
 		examples := docPkg.Examples

--- a/cmd/gomarkdown/output.go
+++ b/cmd/gomarkdown/output.go
@@ -363,6 +363,12 @@ import {{.ImportPath}}
 {{comment 0 4 .Doc}}
 {{end}}
 {{end}}
+{{- if .Examples}}
+### Examples
+{{range .Examples}}#### {{exampleLink . }}
+{{comment 0 4 .Doc}}
+{{end}}
+{{end}}
 
 {{end}}
 {{end}}

--- a/cmd/gomarkdown/output.go
+++ b/cmd/gomarkdown/output.go
@@ -326,6 +326,44 @@ import {{.ImportPath}}
 {{type .Decl}}
 {{codeEnd}}
 {{comment 0 4 .Doc}}
+
+{{- if .Consts}}
+### Constants
+{{range .Consts}}### {{join .Names ", "}}
+{{codeStart}}
+{{value .Decl}}
+{{codeEnd}}
+{{comment 0 4 .Doc}}
+{{end}}
+{{end}}
+{{- if .Vars}}
+### Variables
+{{range .Vars}}### {{join .Names ", "}}
+{{codeStart}}
+{{value .Decl}}
+{{codeEnd}}
+{{comment 0 4 .Doc}}
+{{end}}
+{{end}}
+{{- if .Funcs}}
+### Functions
+{{range .Funcs}}
+{{codeStart}}
+{{func .Decl}}
+{{codeEnd}}
+{{comment 0 4 .Doc}}
+{{end}}
+{{end}}
+{{- if .Methods}}
+### Methods
+{{range .Methods}}
+{{codeStart}}
+{{func .Decl}}
+{{codeEnd}}
+{{comment 0 4 .Doc}}
+{{end}}
+{{end}}
+
 {{end}}
 {{end}}
 

--- a/locate/README.md
+++ b/locate/README.md
@@ -26,12 +26,64 @@ type HitMask int
 ```
 HitMask encodes the type of object found in a given file.
 
+### Constants
+### HasComment, HasFunction, HasInterface
+```go
+// HasComment is set if the current file contains a comment.
+HasComment HitMask = 1 << iota
+// HasFunction is set if the current file contains a function.
+HasFunction
+// HasInterface is set if the current file contains an interface.
+HasInterface
+
+```
+
+
+
+### Methods
+
+```go
+func (hm HitMask) String() string
+```
+
+
+
+
 ### Type Option
 ```go
 type Option func(*options)
 ```
 Option represents an option for controlling the behaviour of locate.T
 instances.
+
+### Functions
+
+```go
+func Concurrency(c int) Option
+```
+Concurrency sets the number of goroutines to use. 0 implies no limit.
+
+
+```go
+func IgnoreMissingFuctionsEtc() Option
+```
+IgnoreMissingFuctionsEtc prevents errors due to packages not containing any
+exported matching interfaces and functions.
+
+
+```go
+func IncludeTests() Option
+```
+IncludeTests includes test code from all requested packages.
+
+
+```go
+func Trace(fn func(string, ...interface{})) Option
+```
+Trace sets a trace function.
+
+
+
 
 ### Type T
 ```go
@@ -40,6 +92,148 @@ type T struct {
 }
 ```
 T represents the ability to locate functions and interface implementations.
+
+### Functions
+
+```go
+func New(options ...Option) *T
+```
+New returns a new instance of T.
+
+
+
+### Methods
+
+```go
+func (t *T) AddComments(comments ...string)
+```
+AddComments adds regular expressions to be matched against the contents of
+comments.
+
+
+```go
+func (t *T) AddFunctions(functions ...string)
+```
+AddFunctions adds functions to be located. The function names are specified
+as fully qualified names with a regular expression being accepted for the
+package local component as per AddInterfaces.
+
+
+```go
+func (t *T) AddInterfaces(interfaces ...string)
+```
+AddInterfaces adds interfaces whose implementations are to be located. The
+interface names are specified as fully qualified type names with a regular
+expression being accepted for the package local component, or as a go list
+expression (ie. one that starts with ./ or contains '...'). For example, all
+of the following match all interfaces in acme.com/a/b:
+
+    acme.com/a/b
+    acme.com/a/b.
+    acme.com/a/b..*
+
+Note that the . separator in the type name is not used as part of the
+regular expression. The following will match a subset of the interfaces:
+
+    acme.com/a/b.prefix
+    acme.com/a/b.thisInterface$
+
+Note that the two forms 'go list' and <package>.<regex> cannot be combined.
+
+
+```go
+func (t *T) AddPackages(packages ...string)
+```
+AddPackages adds packages that will be searched for implementations of
+interfaces specified via AddInterfaces.
+
+
+```go
+func (t *T) Do(ctx context.Context) error
+```
+Do locates implementations of previously added interfaces and functions.
+
+
+```go
+func (t *T) MakeCommentMaps() map[*ast.File]ast.CommentMap
+```
+MakeCommentMaps creates a new ast.CommentMap for every processed file.
+CommentMaps are expensive to create and hence should be created once and
+reused.
+
+
+```go
+func (t *T) WalkComments(fn func(
+	re string,
+	absoluteFilename string,
+	node ast.Node,
+	cg *ast.CommentGroup,
+	pkg *packages.Package,
+	file *ast.File,
+))
+```
+WalkComments calls the supplied function for each comment that was matched
+by the specified regular expressions. The function is called with the
+absolute filename, the node that the comment is associated with, the comment
+and the packates.Package to which the file belongs and its ast. The function
+is called in order of filename and then position within filename.
+
+
+```go
+func (t *T) WalkFiles(fn func(
+	absoluteFilename string,
+	pkg *packages.Package,
+	comments ast.CommentMap,
+	file *ast.File,
+	has HitMask,
+))
+```
+WalkFiles calls the supplied function for each file that contains a located
+comment, interface or function, ordered by filename. The function is called
+with the absolute file name of the file, the packages.Package to which it
+belongs and its ast. The function is called in order of filename and then
+position within filename.
+
+
+```go
+func (t *T) WalkFunctions(fn func(
+	fullname string,
+	pkg *packages.Package,
+	file *ast.File,
+	fn *types.Func,
+	decl *ast.FuncDecl,
+	implements []string))
+```
+WalkFunctions calls the supplied function for each function location,
+ordered by filename and then position within file. The function is called
+with the packages.Package and ast for the file that contains the function,
+as well as the type and declaration of the function and the list of
+interfaces that implements. The function is called in order of filename and
+then position within filename.
+
+
+```go
+func (t *T) WalkInterfaces(fn func(
+	fullname string,
+	pkg *packages.Package,
+	file *ast.File,
+	decl *ast.TypeSpec,
+	ifc *types.Interface))
+```
+WalkInterfaces calls the supplied function for each interface location,
+ordered by filename and then position within file. The function is called
+with the packages.Package and ast for the file that contains the interface,
+as well as the type and declaration of the interface.
+
+
+```go
+func (t *T) WalkPackages(fn func(pkg *packages.Package))
+```
+WalkPackages calls the supplied function for each package loaded. The
+function is called in lexicographic order of package path.
+
+
+
 
 
 

--- a/locate/locateutil/README.md
+++ b/locate/locateutil/README.md
@@ -96,5 +96,16 @@ type FuncDesc struct {
 FuncDesc represents a function definition, declaration and the file and
 position within that file. Decl will be nil if Abstract is true.
 
+### Functions
+
+```go
+func Functions(pkg *packages.Package, re *regexp.Regexp, noMethods bool) []FuncDesc
+```
+Functions returns the functions in the supplied package that match the
+regular expression. If noMethods is false then methods are also returned.
+
+
+
+
 
 


### PR DESCRIPTION
This PR extends the output of gomarkdown to include the functions, methods, consts and vars
associated with a type rather than just the top-level ones.